### PR TITLE
MUST_REVERT: Don't use YV12 color format for video decoding

### DIFF
--- a/media/libstagefright/colorconversion/SoftwareRenderer.cpp
+++ b/media/libstagefright/colorconversion/SoftwareRenderer.cpp
@@ -112,9 +112,11 @@ void SoftwareRenderer::resetFormatIfChanged(const sp<AMessage> &format) {
             case OMX_COLOR_FormatYUV420SemiPlanar:
             case OMX_TI_COLOR_FormatYUV420PackedSemiPlanar:
             {
+#if 0
                 halFormat = HAL_PIXEL_FORMAT_YV12;
                 bufWidth = (mCropWidth + 1) & ~1;
                 bufHeight = (mCropHeight + 1) & ~1;
+#endif
                 break;
             }
             case OMX_COLOR_Format24bitRGB888:


### PR DESCRIPTION
S/w decoder can work with RGB565 that is supported by OpenGLES implementation.
Once YV12 is supported this has to be reverted. This has to be reverted when
enabling h/w decoder as well

Change-Id: Ib7111f2a35f65c451833e05abdf08171f4a2b687
Signed-off-by: Daniel Charles daniel.charles@intel.com

Conflicts:
    media/libstagefright/colorconversion/SoftwareRenderer.cpp
